### PR TITLE
调整游戏事件继承结构 抽象雷暴和物品雨生成方法

### DIFF
--- a/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/AbstractEvent.java
+++ b/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/AbstractEvent.java
@@ -42,6 +42,17 @@ public abstract class AbstractEvent {
         }
     }
 
+    /**
+     * 获取格式化的事件名称, 默认是事件名. 由于设计上的原因
+     * 大多数时候格式化名称会随着倒计时改变, 所以默认countdown
+     * 参数是必须的, 但也有特例.
+     *
+     * @param countdown 距离事件发生的时间, 单位秒
+     * @return 事件名称
+     *
+     * @see moe.caa.fabric.hadesgame.server.gameevent.coreevent
+     * @see ImplicitAbstractEvent
+     */
     public String getFormatEventName(int countdown) {
         return EVENT_NAME;
     }

--- a/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/ImplicitAbstractEvent.java
+++ b/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/ImplicitAbstractEvent.java
@@ -1,0 +1,23 @@
+package moe.caa.fabric.hadesgame.server.gameevent;
+
+
+/**
+ * 继承该类的事件直到快要发生时才会在计分板显示自己的名称
+ * @see moe.caa.fabric.hadesgame.server.gameevent.AbstractEvent
+ */
+public abstract class ImplicitAbstractEvent extends AbstractEvent {
+    public ImplicitAbstractEvent(String id, String event_name, boolean should_countdown, int countdown_random_min, int countdown_random_max) {
+        super(id, event_name, should_countdown, countdown_random_min, countdown_random_max);
+    }
+
+    @Override
+    public String getFormatEventName(int countdown) {
+        return getFormatEventName(countdown, 10);
+    }
+
+    public String getFormatEventName(int countdown, int limit) {
+        if (countdown >= limit)
+            return "\u00a7k********";
+        return EVENT_NAME;
+    }
+}

--- a/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/LuminescenceEvent.java
+++ b/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/LuminescenceEvent.java
@@ -4,16 +4,9 @@ import moe.caa.fabric.hadesgame.server.GameCore;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.effect.StatusEffects;
 
-public class LuminescenceEvent extends AbstractEvent {
+public class LuminescenceEvent extends ImplicitAbstractEvent {
     public LuminescenceEvent() {
         super("luminescence", "发光", true, 60, 120);
-    }
-
-    @Override
-    public String getFormatEventName(int countdown) {
-        if (countdown >= 10)
-            return "\u00a7k********";
-        return super.EVENT_NAME;
     }
 
     @Override

--- a/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/NarrowRangeEvent.java
+++ b/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/NarrowRangeEvent.java
@@ -3,16 +3,9 @@ package moe.caa.fabric.hadesgame.server.gameevent;
 import moe.caa.fabric.hadesgame.server.HadesGame;
 import net.minecraft.world.border.WorldBorder;
 
-public class NarrowRangeEvent extends AbstractEvent {
+public class NarrowRangeEvent extends ImplicitAbstractEvent {
     public NarrowRangeEvent() {
         super("narrowRange", "缩圈", true, 60, 120);
-    }
-
-    @Override
-    public String getFormatEventName(int countdown) {
-        if (countdown >= 10)
-            return "\u00a7k********";
-        return super.EVENT_NAME;
     }
 
     @Override

--- a/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/RainAnvilEvent.java
+++ b/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/RainAnvilEvent.java
@@ -10,16 +10,9 @@ import net.minecraft.util.math.BlockPos;
 
 import java.util.Random;
 
-public class RainAnvilEvent extends AbstractEvent {
+public class RainAnvilEvent extends ImplicitAbstractEvent {
     public RainAnvilEvent() {
         super("rainAnvil", "铁砧雨", true, 60, 120);
-    }
-
-    @Override
-    public String getFormatEventName(int countdown) {
-        if (countdown >= 10)
-            return "\u00a7k********";
-        return super.EVENT_NAME;
     }
 
     @Override

--- a/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/RainItemsEvent.java
+++ b/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/RainItemsEvent.java
@@ -6,19 +6,13 @@ import moe.caa.fabric.hadesgame.server.schedule.AbstractTick;
 import moe.caa.fabric.hadesgame.server.schedule.HadesGameScheduleManager;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
 
 import java.util.Random;
 
-public class RainItemsEvent extends AbstractEvent {
+public class RainItemsEvent extends ImplicitAbstractEvent {
     public RainItemsEvent() {
         super("rainItem", "物品雨", true, 60, 120);
-    }
-
-    @Override
-    public String getFormatEventName(int countdown) {
-        if (countdown >= 10)
-            return "\u00a7k********";
-        return super.EVENT_NAME;
     }
 
     @Override
@@ -26,42 +20,32 @@ public class RainItemsEvent extends AbstractEvent {
         Random random = new Random();
 
         GameCore.INSTANCE.survivalPlayerHandler(p -> {
-            double x = p.getX();
-            double z = p.getZ();
-
-            for (int i = 0; i < 10; i++) {
-                double spawnX = x - 5 + random.nextInt(10);
-                double spawnZ = z - 5 + random.nextInt(10);
-                p.world.spawnEntity(new ItemEntity(p.world, spawnX, 250, spawnZ, new ItemStack(HadesGame.ITEM_WEIGHT_RANDOM_ARRAY_LIST.randomGet())));
-            }
+            generateItems(random, p);
 
             HadesGameScheduleManager.INSTANCE.delayRunTask.put(new AbstractTick() {
                 @Override
                 protected void tick() {
-                    double x = p.getX();
-                    double z = p.getZ();
-
-                    for (int i = 0; i < 10; i++) {
-                        double spawnX = x - 5 + random.nextInt(10);
-                        double spawnZ = z - 5 + random.nextInt(10);
-                        p.world.spawnEntity(new ItemEntity(p.world, spawnX, 250, spawnZ, new ItemStack(HadesGame.ITEM_WEIGHT_RANDOM_ARRAY_LIST.randomGet())));
-                    }
+                    generateItems(random, p);
                 }
             }, 40);
 
             HadesGameScheduleManager.INSTANCE.delayRunTask.put(new AbstractTick() {
                 @Override
                 protected void tick() {
-                    double x = p.getX();
-                    double z = p.getZ();
-
-                    for (int i = 0; i < 10; i++) {
-                        double spawnX = x - 5 + random.nextInt(10);
-                        double spawnZ = z - 5 + random.nextInt(10);
-                        p.world.spawnEntity(new ItemEntity(p.world, spawnX, 250, spawnZ, new ItemStack(HadesGame.ITEM_WEIGHT_RANDOM_ARRAY_LIST.randomGet())));
-                    }
+                    generateItems(random, p);
                 }
             }, 80);
         });
+    }
+
+    private void generateItems(Random random, ServerPlayerEntity p) {
+        double x = p.getX();
+        double z = p.getZ();
+
+        for (int i = 0; i < 10; i++) {
+            double spawnX = x - 5 + random.nextInt(10);
+            double spawnZ = z - 5 + random.nextInt(10);
+            p.world.spawnEntity(new ItemEntity(p.world, spawnX, 250, spawnZ, new ItemStack(HadesGame.ITEM_WEIGHT_RANDOM_ARRAY_LIST.randomGet())));
+        }
     }
 }

--- a/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/RandomClearInventorySectionEvent.java
+++ b/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/RandomClearInventorySectionEvent.java
@@ -4,16 +4,9 @@ import moe.caa.fabric.hadesgame.server.GameCore;
 import moe.caa.fabric.hadesgame.server.HgPlayerInventory;
 import net.minecraft.item.ItemStack;
 
-public class RandomClearInventorySectionEvent extends AbstractEvent {
+public class RandomClearInventorySectionEvent extends ImplicitAbstractEvent {
     public RandomClearInventorySectionEvent() {
         super("randomClearItem", "随机掉落背包", true, 60, 120);
-    }
-
-    @Override
-    public String getFormatEventName(int countdown) {
-        if (countdown >= 10)
-            return "\u00a7k********";
-        return super.EVENT_NAME;
     }
 
     @Override

--- a/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/RandomEffectEvent.java
+++ b/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/RandomEffectEvent.java
@@ -4,16 +4,9 @@ import moe.caa.fabric.hadesgame.server.GameCore;
 import moe.caa.fabric.hadesgame.server.HadesGame;
 import net.minecraft.entity.effect.StatusEffectInstance;
 
-public class RandomEffectEvent extends AbstractEvent {
+public class RandomEffectEvent extends ImplicitAbstractEvent {
     public RandomEffectEvent() {
         super("randomEffect", "随机效果", true, 60, 120);
-    }
-
-    @Override
-    public String getFormatEventName(int countdown) {
-        if (countdown >= 10)
-            return "\u00a7k********";
-        return super.EVENT_NAME;
     }
 
     @Override

--- a/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/SwapHealthEvent.java
+++ b/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/SwapHealthEvent.java
@@ -10,16 +10,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class SwapHealthEvent extends AbstractEvent {
+public class SwapHealthEvent extends ImplicitAbstractEvent {
     public SwapHealthEvent() {
         super("swapHealth", "生命互换", true, 60, 120);
-    }
-
-    @Override
-    public String getFormatEventName(int countdown) {
-        if (countdown >= 10)
-            return "\u00a7k********";
-        return super.EVENT_NAME;
     }
 
     @Override

--- a/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/SwapInventoryEvent.java
+++ b/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/SwapInventoryEvent.java
@@ -10,16 +10,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class SwapInventoryEvent extends AbstractEvent {
+public class SwapInventoryEvent extends ImplicitAbstractEvent {
     public SwapInventoryEvent() {
         super("swapInventory", "背包互换", true, 60, 120);
-    }
-
-    @Override
-    public String getFormatEventName(int countdown) {
-        if (countdown >= 10)
-            return "\u00a7k********";
-        return super.EVENT_NAME;
     }
 
     @Override

--- a/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/SwapLocationEvent.java
+++ b/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/SwapLocationEvent.java
@@ -10,16 +10,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class SwapLocationEvent extends AbstractEvent {
+public class SwapLocationEvent extends ImplicitAbstractEvent {
     public SwapLocationEvent() {
         super("swapLocation", "斗转星移", true, 60, 120);
-    }
-
-    @Override
-    public String getFormatEventName(int countdown) {
-        if (countdown >= 10)
-            return "\u00a7k********";
-        return super.EVENT_NAME;
     }
 
     @Override

--- a/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/ThunderstormEvent.java
+++ b/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/ThunderstormEvent.java
@@ -6,21 +6,15 @@ import moe.caa.fabric.hadesgame.server.schedule.HadesGameScheduleManager;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.world.Heightmap;
 
 import java.util.Random;
 
-public class ThunderstormEvent extends AbstractEvent {
+public class ThunderstormEvent extends ImplicitAbstractEvent {
     public ThunderstormEvent() {
         super("thunderstorm", "雷暴", true, 60, 120);
-    }
-
-    @Override
-    public String getFormatEventName(int countdown) {
-        if (countdown >= 10)
-            return "\u00a7k********";
-        return super.EVENT_NAME;
     }
 
     @Override
@@ -28,57 +22,37 @@ public class ThunderstormEvent extends AbstractEvent {
         Random random = new Random();
 
         GameCore.INSTANCE.survivalPlayerHandler(player -> {
-            double x = player.getPos().x - 2 + random.nextInt(4);
-            double z = player.getPos().z - 2 + random.nextInt(4);
-
-            CompoundTag nbt = new CompoundTag();
-            int y = player.world.getTopY(Heightmap.Type.MOTION_BLOCKING, (int) x, (int) z);
-
-            nbt.putString("id", "minecraft:lightning_bolt");
-            Entity entity2 = EntityType.loadEntityWithPassengers(nbt, player.world, (entityx) -> {
-                entityx.refreshPositionAndAngles(x, y, z, entityx.prevYaw, entityx.prevPitch);
-                return entityx;
-            });
-
-            ((ServerWorld) player.world).shouldCreateNewEntityWithPassenger(entity2);
+            generateLightBolts(random, player);
 
             HadesGameScheduleManager.INSTANCE.delayRunTask.put(new AbstractTick() {
                 @Override
                 protected void tick() {
-                    double x = player.getPos().x - 2 + random.nextInt(4);
-                    double z = player.getPos().z - 2 + random.nextInt(4);
-
-                    CompoundTag nbt = new CompoundTag();
-                    int y = player.world.getTopY(Heightmap.Type.MOTION_BLOCKING, (int) x, (int) z);
-
-                    nbt.putString("id", "minecraft:lightning_bolt");
-                    Entity entity2 = EntityType.loadEntityWithPassengers(nbt, player.world, (entityx) -> {
-                        entityx.refreshPositionAndAngles(x, y, z, entityx.prevYaw, entityx.prevPitch);
-                        return entityx;
-                    });
-
-                    ((ServerWorld) player.world).shouldCreateNewEntityWithPassenger(entity2);
+                    generateLightBolts(random, player);
                 }
             }, 40);
 
             HadesGameScheduleManager.INSTANCE.delayRunTask.put(new AbstractTick() {
                 @Override
                 protected void tick() {
-                    double x = player.getPos().x - 2 + random.nextInt(4);
-                    double z = player.getPos().z - 2 + random.nextInt(4);
-
-                    CompoundTag nbt = new CompoundTag();
-                    int y = player.world.getTopY(Heightmap.Type.MOTION_BLOCKING, (int) x, (int) z);
-
-                    nbt.putString("id", "minecraft:lightning_bolt");
-                    Entity entity2 = EntityType.loadEntityWithPassengers(nbt, player.world, (entityx) -> {
-                        entityx.refreshPositionAndAngles(x, y, z, entityx.prevYaw, entityx.prevPitch);
-                        return entityx;
-                    });
-
-                    ((ServerWorld) player.world).shouldCreateNewEntityWithPassenger(entity2);
+                    generateLightBolts(random, player);
                 }
             }, 80);
         });
+    }
+
+    private void generateLightBolts(Random random, ServerPlayerEntity player) {
+        double x = player.getPos().x - 2 + random.nextInt(4);
+        double z = player.getPos().z - 2 + random.nextInt(4);
+
+        CompoundTag nbt = new CompoundTag();
+        int y = player.world.getTopY(Heightmap.Type.MOTION_BLOCKING, (int) x, (int) z);
+
+        nbt.putString("id", "minecraft:lightning_bolt");
+        Entity entity2 = EntityType.loadEntityWithPassengers(nbt, player.world, (entity) -> {
+            entity.refreshPositionAndAngles(x, y, z, entity.prevYaw, entity.prevPitch);
+            return entity;
+        });
+
+        ((ServerWorld) player.world).shouldCreateNewEntityWithPassenger(entity2);
     }
 }

--- a/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/TreatmentEvent.java
+++ b/src/main/java/moe/caa/fabric/hadesgame/server/gameevent/TreatmentEvent.java
@@ -4,16 +4,9 @@ import moe.caa.fabric.hadesgame.server.GameCore;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.effect.StatusEffects;
 
-public class TreatmentEvent extends AbstractEvent {
+public class TreatmentEvent extends ImplicitAbstractEvent {
     public TreatmentEvent() {
         super("treatment", "治疗", true, 60, 120);
-    }
-
-    @Override
-    public String getFormatEventName(int countdown) {
-        if (countdown >= 10)
-            return "\u00a7k********";
-        return super.EVENT_NAME;
     }
 
     @Override


### PR DESCRIPTION
[新增] 抽象类ImplicitAbstract,继承自AbstractEvent. 事件名称在事件发生前的一段时间需要隐藏的事件现在继承自该类而不是AbstractEvent类. 同时这些事件的getFormatEventName(countdown)方法实现转移到了父类中
[修改] RainItemsEvent类中生成物品的过程抽象为generateItems(random, player)方法
[修改] ThunderstormEvent类中生成雷暴的过程抽象为generateLightBolts(random, player)方法